### PR TITLE
Fix $PATH issues with Lilypond display() hooks

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -5,3 +5,4 @@ Caleb Smith <caleb.smithnc@gmail.com>
 Paul Marganian <paul.marganian@gmail.com>
 Sean McQuillan <mcquillan.sean@gmail.com>
 Brantley Harris <deadwisdom@gmail.com>
+Anton I. Sipos <aisipos@gmail.com>

--- a/sebastian/core/elements.py
+++ b/sebastian/core/elements.py
@@ -101,10 +101,14 @@ class SeqBase(object):
         basename = f.name[:-len(suffix)]
         args.extend(["-o"+basename, "-"])
 
-        p = sp.Popen(args, stdin=sp.PIPE)
-        p.communicate(write_lilypond.output(seq))
+        #Pass shell=True so that if your $PATH contains ~ it will
+        #get expanded. This also changes the way the arguments get
+        #passed in. To work correctly, pass them as a string
+        p = sp.Popen(" ".join(args), stdin=sp.PIPE, shell=True)
+        stdout, stderr = p.communicate(write_lilypond.output(seq))
         if p.returncode != 0:
             # there was an error
+            #raise IOError("Lilypond execution failed: %s%s" % (stdout, stderr))
             return None
 
         if not ipython:


### PR DESCRIPTION
By default, subprocess doesn't send it's command through a shell for processing. Among other things, this means '~' chars in the path don't get expanded. Since this is probably a common occurrence on many $PATH vars, we should use shell=True in the arguments to subprocess.

tl;dr, but if you want, see:
http://docs.python.org/2/library/subprocess.html
http://stackoverflow.com/questions/5658622/python-subprocess-popen-environment-path
http://bugs.python.org/issue8557
